### PR TITLE
Fix encode

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,2 @@
-export { encode } from "https://deno.land/std/strings/mod.ts";
+export const encode = new TextEncoder().encode;
 export { Hash, hex } from "./hash.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,3 @@
-export const encode = new TextEncoder().encode;
+const encoder = new TextEncoder();
+export const encode = (str: string) => encoder.encode(str);
 export { Hash, hex } from "./hash.ts";


### PR DESCRIPTION
Fixed encode due to `https://deno.land/std/strings/mod.ts` no longer being supported in the standard library. The fix should work just like it did before. I am split on what i think of even re-exporting such a simple function and think it would be better for the project to just recommend writing `new TextEncoder().encode(stuffThatNeedsEncoding);` or use [ende](https://github.com/rsp/deno-ende) instead.