### PR TITLE
be compatible with deno v0.41.0

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,7 @@
+export {
+  decode,
+  encode
+} from "https://deno.land/std@v0.41.0/encoding/utf8.ts";
+export {
+  assertEquals
+} from "https://deno.land/std@v0.41.0/testing/asserts.ts";

--- a/md5.test.ts
+++ b/md5.test.ts
@@ -1,5 +1,4 @@
-import { encode } from "https://deno.land/std@v0.35.0/strings/encode.ts";
-import { assertEquals } from "https://deno.land/std@v0.35.0/testing/asserts.ts";
+import { assertEquals, encode } from "./deps.ts";
 import { Hash, hex } from "./hash.ts";
 
 const { test } = Deno;

--- a/sha1.test.ts
+++ b/sha1.test.ts
@@ -1,5 +1,4 @@
-import { encode } from "https://deno.land/std@v0.35.0/strings/encode.ts";
-import { assertEquals } from "https://deno.land/std@v0.35.0/testing/asserts.ts";
+import { assertEquals, encode } from "./deps.ts";
 import { Hash, hex } from "./hash.ts";
 
 const { test } = Deno;


### PR DESCRIPTION
This PR does the following:

- Addresses breaking changes in https://github.com/denoland/deno/releases/tag/v0.39.0
- Makes sure tests are passing after addressing breaking changes
- Implements use of `deps.ts` file

This PR does NOT include a tag.