### PR TITLE
Fix for Deno v1.4.0

### DIFF
--- a/sha1.ts
+++ b/sha1.ts
@@ -1,4 +1,4 @@
-import { HashAlgorithm } from "./hash.ts";
+import type { HashAlgorithm } from "./hash.ts";
 
 /*
  * Calculate the SHA-1 of an array of big-endian words, and a bit length


### PR DESCRIPTION
You will get the following errors in the terminal if you don't merge this:

```terminal
TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { HashAlgorithm } from "./hash.ts";
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at https://deno.land/x/checksum@1.4.0/sha1.ts:1:1

TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { HashAlgorithm } from "./hash.ts";
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at https://deno.land/x/checksum@1.4.0/md5.ts:1:
```